### PR TITLE
Removing data from sdata in each iteration.

### DIFF
--- a/src/mf4parser.py
+++ b/src/mf4parser.py
@@ -25,6 +25,7 @@ class mdfSubset:
             for signals in range(len(signalCsv)): #len(signalCsv iterate for all signal in the CSV
                 try:                      
                     sg_pos=mf4data.whereis(signalCsv.Signal[signals])            
+                    sdata = None            
                     for k in range(len(sg_pos)): # valid group and channel selection
                         gr_nr = sg_pos[k][0] # k is the list index of available channel groups
                         ch_nr = sg_pos[k][1] 


### PR DESCRIPTION
`createSubset()` has possible logical bug. If you provide a signal in **signalList_sample.csv** which is not in mf4 file then you can see the effect. How to recreate the issue?

Provide following data in CSV where **XYZ** is not in mf4 file.

```
Name | Type | Signal  

Speed2D | Cont | Speed2D  

AngleRoll | Cont | AngleRoll

XYZ | Cont | XYZ

StationarySpeed | Cont | StationarySpeed
```


Now during execution when signal is **XYZ**, `sg_pos` will be empty and interpreter will skip the `for` loop but it will enter the next `if` condition as the `sdata` is not empty. Due to this, in the end of function `subsetList` will contain 4 signals with 2 signals having `name' as **XYZ**.

Resolution:
Before second for loop, remove content of `sdata`
```
sdata = None
```